### PR TITLE
Refactor count_leap_years() and add test cases

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Check formatting
       run: cargo fmt -- --check
     - name: Build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,9 +22,9 @@ dependencies = [
 
 [[package]]
 name = "argh"
-version = "0.1.7"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb41d85d92dfab96cb95ab023c265c5e4261bb956c0fb49ca06d90c570f1958"
+checksum = "c375edecfd2074d5edcc31396860b6e54b6f928714d0e097b983053fac0cabe3"
 dependencies = [
  "argh_derive",
  "argh_shared",
@@ -32,9 +32,9 @@ dependencies = [
 
 [[package]]
 name = "argh_derive"
-version = "0.1.7"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be69f70ef5497dd6ab331a50bd95c6ac6b8f7f17a7967838332743fbd58dc3b5"
+checksum = "aa013479b80109a1bf01a039412b0f0013d716f36921226d86c6709032fb7a03"
 dependencies = [
  "argh_shared",
  "heck",
@@ -45,9 +45,9 @@ dependencies = [
 
 [[package]]
 name = "argh_shared"
-version = "0.1.7"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6f8c380fa28aa1b36107cd97f0196474bb7241bb95a453c5c01a15ac74b2eac"
+checksum = "149f75bbec1827618262e0855a68f0f9a7f2edc13faebf33c4f16d6725edb6a9"
 
 [[package]]
 name = "autocfg"
@@ -76,12 +76,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "lazy_static"
@@ -244,12 +241,6 @@ dependencies = [
  "wasi",
  "winapi",
 ]
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["calendar", "cal"]
 categories = ["command-line-utilities"]
 
 [dependencies]
-argh = "0.1.4"
+argh = "0.1.9"
 chrono = "0.4"
 locale_config = "0.3.0"
 pure-rust-locales = "0.5.6"

--- a/README.md
+++ b/README.md
@@ -87,4 +87,5 @@ Enable colored output with the `--color` or `-c` option. This highlights weekend
 ```sh
 $ rusti-cal <year> --color
 ```
+
 ![colored](./doc/colored.png)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -437,7 +437,7 @@ fn test_days_by_month() {
         assert_eq!(
             days_by_month(test_case.0),
             test_case.1,
-            "Year {} is not a leap year",
+            "Year {}",
             test_case.0
         );
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -345,3 +345,12 @@ fn test_circular_week_name_pt_br() {
     let week_name = locale_info.week_day_names();
     assert_eq!(circular_week_name(week_name, 0), " Do Se Te Qu Qu Se Sá");
 }
+
+#[test]
+fn test_is_leap_year() {
+    assert_eq!(is_leap_year(2022), false, "2022 is not a leap year");
+    assert_eq!(is_leap_year(2023), false, "2023 is not a leap year");
+    assert_eq!(is_leap_year(2025), false, "2025 is not a leap year");
+
+    assert_eq!(is_leap_year(2024), true, "2024 is a leap year");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -307,7 +307,7 @@ pub fn display_colored(year: u32, locale_str: &str, starting_day: u32) {
                             (false, 0)
                         }
                     };
-                    // print the colred line
+                    // print the colored line
                     print_colored_row(&row[col][line], starting_day, today_included, x);
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,9 +28,7 @@ fn is_leap_year(year: u32) -> bool {
 }
 
 fn count_leap_years(year: u32) -> u32 {
-    if year < 1 {
-        0
-    } else if year <= REFORM_YEAR {
+    if year <= REFORM_YEAR {
         (year - 1) / 4
     } else {
         ((year - 1) / 4) - ((year - 1) / 100) + ((year - 1) / 400) + SPECIAL_LEAP_YEARS

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -370,7 +370,6 @@ fn test_is_leap_year() {
 #[test]
 fn test_count_leap_years() {
     let test_cases = [
-        (0, 0),
         (400, 99),
         (401, 100),
         (1100, 274),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,10 @@ use ansi_term::{
 use chrono::Datelike;
 
 const REFORM_YEAR: u32 = 1099;
+
+// SPECIAL_LEAP_YEARS are years before REFORM_YEAR that are divisible by 100, but not by 400.
+const SPECIAL_LEAP_YEARS: u32 = (REFORM_YEAR / 100) - (REFORM_YEAR / 400);
+
 const MONTHS: usize = 12;
 const WEEKDAYS: u32 = 7;
 
@@ -23,26 +27,26 @@ fn is_leap_year(year: u32) -> bool {
     (year % 4 == 0) ^ (year % 100 == 0) ^ (year % 400 == 0)
 }
 
-fn days_by_year(mut year: u32) -> u32 {
-    let mut count: u32 = 0;
-
-    while year > 1 {
-        year -= 1;
-        if is_leap_year(year) {
-            count += 366
-        } else {
-            count += 365
-        }
+fn count_leap_years(year: u32) -> u32 {
+    if year < 1 {
+        0
+    } else if year <= REFORM_YEAR {
+        (year - 1) / 4
+    } else {
+        ((year - 1) / 4) - ((year - 1) / 100) + ((year - 1) / 400) + SPECIAL_LEAP_YEARS
     }
-    count
+}
+
+fn days_by_year(year: u32) -> u32 {
+    if year < 1 {
+        0
+    } else {
+        (year - 1) * 365 + count_leap_years(year)
+    }
 }
 
 fn days_by_month(year: u32) -> Vec<u32> {
-    let mut feb_day: u32 = 28;
-
-    if is_leap_year(year) {
-        feb_day = 29;
-    }
+    let feb_day: u32 = if is_leap_year(year) { 29 } else { 28 };
     vec![0, 31, feb_day, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
 }
 
@@ -53,16 +57,11 @@ fn days_by_date(
     months_memoized: Vec<u32>,
     year_memoized: u32,
 ) -> u32 {
-    let mut count = 0;
-
-    count += day;
-    if month > 1 {
-        count += months_memoized[month - 1]
-    }
-    if year > 1 {
-        count += year_memoized
-    }
-    count
+    day + (if month > 1 {
+        months_memoized[month - 1]
+    } else {
+        0
+    }) + (if year > 1 { year_memoized } else { 0 })
 }
 
 fn get_days_accumulated_by_month(year: u32) -> (Vec<u32>, Vec<u32>) {
@@ -348,9 +347,122 @@ fn test_circular_week_name_pt_br() {
 
 #[test]
 fn test_is_leap_year() {
-    assert_eq!(is_leap_year(2022), false, "2022 is not a leap year");
-    assert_eq!(is_leap_year(2023), false, "2023 is not a leap year");
-    assert_eq!(is_leap_year(2025), false, "2025 is not a leap year");
+    let test_cases = [
+        (100, true),
+        (400, true),
+        (1000, true),
+        (1100, false),
+        (2022, false),
+        (2023, false),
+        (2024, true),
+        (2025, false),
+        (2300, false),
+    ];
+    for test_case in test_cases.iter() {
+        assert_eq!(
+            is_leap_year(test_case.0),
+            test_case.1,
+            "{} is {} a leap year",
+            test_case.0,
+            if test_case.1 { "" } else { "not" }
+        );
+    }
+}
 
-    assert_eq!(is_leap_year(2024), true, "2024 is a leap year");
+#[test]
+fn test_count_leap_years() {
+    let test_cases = [
+        (0, 0),
+        (400, 99),
+        (401, 100),
+        (1100, 274),
+        (1200, 298),
+        (2022, 498),
+    ];
+    for test_case in test_cases.iter() {
+        assert_eq!(
+            count_leap_years(test_case.0),
+            test_case.1,
+            "Year {}",
+            test_case.0
+        );
+    }
+}
+
+#[test]
+fn test_days_by_year() {
+    let test_cases = [
+        (0, 0),
+        (1, 0),
+        (2, 365),
+        (3, 730),
+        (4, 1095),
+        (5, 1461),
+        (6, 1826),
+        (7, 2191),
+        (8, 2556),
+        (9, 2922),
+        (10, 3287),
+        (400, 145734),
+        (401, 146100),
+        (402, 146465),
+        (403, 146830),
+        (404, 147195),
+        (800, 291834),
+        (801, 292200),
+        (802, 292565),
+        (803, 292930),
+        (804, 293295),
+        (2022, 738163),
+        (2023, 738528),
+        (2024, 738893),
+        (2025, 739259),
+    ];
+    for test_case in test_cases.iter() {
+        assert_eq!(
+            days_by_year(test_case.0),
+            test_case.1,
+            "Year {}",
+            test_case.0
+        );
+    }
+}
+
+#[test]
+fn test_days_by_month() {
+    let not_leap = vec![0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    let leap = vec![0, 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    let test_cases = [(2022, not_leap), (2024, leap)];
+    for test_case in test_cases.iter() {
+        assert_eq!(
+            days_by_month(test_case.0),
+            test_case.1,
+            "Year {} is not a leap year",
+            test_case.0
+        );
+    }
+}
+
+#[test]
+fn test_days_by_date() {
+    assert_eq!(
+        days_by_date(
+            0,
+            0,
+            0,
+            vec![0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
+            1
+        ),
+        0
+    );
+    assert_eq!(
+        days_by_date(
+            7,
+            4,
+            0,
+            vec![0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
+            1
+        ),
+        38
+    );
 }

--- a/src/locale.rs
+++ b/src/locale.rs
@@ -58,6 +58,7 @@ fn parse_default_locale() {
     assert_eq!(res.locale, Locale::POSIX);
 
     let months = res.month_names();
+    assert_eq!(months.len(), 12);
     assert_eq!(months[0], "January");
     assert_eq!(months[1], "February");
     assert_eq!(months[2], "March");
@@ -81,6 +82,7 @@ fn parse_english_locale() {
     assert_eq!(res.locale, Locale::en_AU);
 
     let months = res.month_names();
+    assert_eq!(months.len(), 12);
     assert_eq!(months[0], "January");
     assert_eq!(months[1], "February");
     assert_eq!(months[2], "March");
@@ -104,6 +106,7 @@ fn parse_non_english_locale() {
     assert_eq!(res.locale, Locale::hu_HU);
 
     let months = res.month_names();
+    assert_eq!(months.len(), 12);
     assert_eq!(months[0], "Január");
     assert_eq!(months[1], "Február");
     assert_eq!(months[2], "Március");


### PR DESCRIPTION
## Proposed changes

- Refactor leap year functions to not use mut ( count_leap_years() now runs in constant time )
- Add some test cases for leap year functions
- Upgrade actions/checkout to v3
- Upgrade argh to 0.1.9
- Lint README and comment spelling error