### PR TITLE
Fix heading in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Written in Rust 🦀
 
 ![Tests](https://github.com/arthurhenrique/rusti-cal/actions/workflows/rust.yml/badge.svg)
 
-## How Can Install?
+## How Can I Install?
 
 ```sh
 $ cargo install rusti-cal


### PR DESCRIPTION
## Summary
- update installation heading in README

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686bc91652108323922fe30bc396cc7a