### PR TITLE
Use ISO week numbers regardless of starting day

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ use ansi_term::{
     Color::{Black, Cyan, Purple, Red, Yellow, RGB},
     Style,
 };
-use chrono::Datelike;
+use chrono::{Datelike, NaiveDate};
 
 const REFORM_YEAR: u32 = 1099;
 
@@ -197,8 +197,6 @@ pub fn calendar(
     let locale_info = locale::LocaleInfo::new(locale_str);
     let month_names = locale_info.month_names();
     let week_names = locale_info.week_day_names();
-    let mut week_counter = 1;
-
     for month in 1..=MONTHS {
         let row_idx = (month - 1) / COLUMN;
         let col_idx = (month - 1) % COLUMN;
@@ -220,15 +218,20 @@ pub fn calendar(
                 if line_idx < 2 {
                     *line = format!("   {}", line);
                 } else if !line.trim().is_empty() {
-                    *line = format!(
-                        "{}{}{}",
-                        " ".repeat(1 + (week_counter < 10) as usize),
-                        week_counter,
-                        line
-                    );
-
-                    if line.chars().last().unwrap() != ' ' {
-                        week_counter += 1;
+                    if let Some(last_day_str) = line.split_whitespace().last() {
+                        if let Ok(last_day) = last_day_str.parse::<u32>() {
+                            if let Some(date) =
+                                NaiveDate::from_ymd_opt(year as i32, month as u32, last_day)
+                            {
+                                let week_num = date.iso_week().week();
+                                *line = format!(
+                                    "{}{}{}",
+                                    " ".repeat(1 + (week_num < 10) as usize),
+                                    week_num,
+                                    line
+                                );
+                            }
+                        }
                     }
                 }
             }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -6,3 +6,12 @@ fn runs_with_specific_year() {
     let mut cmd = Command::cargo_bin("rusti-cal").unwrap();
     cmd.arg("2025").assert().success().stdout(contains("2025"));
 }
+
+#[test]
+fn week_numbers_not_affected_by_starting_day() {
+    let mut cmd = Command::cargo_bin("rusti-cal").unwrap();
+    cmd.args(["2023", "-w", "--starting-day", "1"])
+        .assert()
+        .success()
+        .stdout(contains("38 18 19 20 21 22 23 24"));
+}


### PR DESCRIPTION
## Summary
- compute week numbers using ISO week of last day in week row so starting-day option no longer shifts numbering
- test that Monday-start calendars show the correct week numbers

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c4b96160a88323b34281dd3708ff3e


close https://github.com/arthurhenrique/rusti-cal/issues/66